### PR TITLE
Update models.py

### DIFF
--- a/inversefed/nn/models.py
+++ b/inversefed/nn/models.py
@@ -12,14 +12,14 @@ from collections import OrderedDict
 import numpy as np
 from ..utils import set_random_seed
 
-
+import random
 
 
 def construct_model(model, num_classes=10, seed=None, num_channels=3, modelkey=None):
     """Return various models."""
     if modelkey is None:
         if seed is None:
-            model_init_seed = np.random.randint(0, 2**32 - 10)
+            model_init_seed = random.randint(0, 2**32 - 10)
         else:
             model_init_seed = seed
     else:


### PR DESCRIPTION
We are replacing the "numpy.random.randint" function with the "random.randint" function from Python's built-in random module in the "construct_model" function within the "models.py" file. The reason for this change is that the NumPy random generator tries to generate a 32-bit integer even when the upper bound value is cast to numpy.int64, which results in a "high is out of bounds for int32" error.

By using "random.randint", we avoid this error and ensure that the random seed for model initialization is generated correctly within the desired range.